### PR TITLE
Simple self-contained error page.

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,11 @@
+
+<script lang="ts">
+  export const { error, status } = $props();
+</script>
+
+<div class="flex flex-col items-center justify-center h-full min-h-[80vh]">
+  <h2 class="text-6xl font-bold mb-4">{status === 404 ? '404' : status}</h2>
+  <h3 class="text-2xl mb-2">{status === 404 ? 'Page Not Found' : 'An error occurred'}</h3>
+  <p class="mb-6">{error?.message || 'Sorry, the page you are looking for does not exist.'}</p>
+  <a href="/" class="px-4 py-2 bg-primary-900 font-bold rounded hover:bg-primary-400 transition" style="color: white; margin-top: 1rem">Go Home</a>
+</div>


### PR DESCRIPTION
Not exactly a substantial contribution, but should be easy to merge.

I was having some trouble with getting tailwind classes like text-white and mt-1 to work, hence the style="" block.

**Appearance Desktop:**
<img width="1782" height="912" alt="image" src="https://github.com/user-attachments/assets/ecc1db23-db81-4784-9893-1de431f87b80" />
**Appearance @ iPhone 11 viewport dimensions:**
<img width="408" height="843" alt="image" src="https://github.com/user-attachments/assets/7723fd6c-c669-458a-b989-0f21359d56d7" />